### PR TITLE
Add ORT scan webapp integration

### DIFF
--- a/config.py
+++ b/config.py
@@ -31,3 +31,6 @@ OWNER_ID = 631573859
 GROUP_ID = -1001932954655
 DATA_FILE = 'schedule.json'
 
+# URL of WebApp used for scanning ORT certificates
+SCANNER_WEBAPP_URL = 'https://hanbiike.github.io/ortscan/'
+


### PR DESCRIPTION
## Summary
- configure scanner webapp URL
- update profile submission message and keyboard
- forward scanned certificate photos to admin

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68610db511ac8332b1cf5a86de67a3f4