### PR TITLE
Add file ID response handler

### DIFF
--- a/handlers/file_id.py
+++ b/handlers/file_id.py
@@ -1,0 +1,45 @@
+from aiogram import Router, types, F
+from methods.users import user_lang
+
+router = Router()
+
+FILE_TYPES = [
+    "photo",
+    "document",
+    "video",
+    "audio",
+    "voice",
+    "animation",
+    "video_note",
+    "sticker",
+]
+
+@router.message(F.content_type.in_(FILE_TYPES))
+async def send_file_id(message: types.Message):
+    if message.chat.type != "private":
+        return
+
+    content_type = message.content_type
+    file_id = None
+
+    if content_type == "photo":
+        file_id = message.photo[-1].file_id
+    elif content_type == "document":
+        file_id = message.document.file_id
+    elif content_type == "video":
+        file_id = message.video.file_id
+    elif content_type == "audio":
+        file_id = message.audio.file_id
+    elif content_type == "voice":
+        file_id = message.voice.file_id
+    elif content_type == "animation":
+        file_id = message.animation.file_id
+    elif content_type == "video_note":
+        file_id = message.video_note.file_id
+    elif content_type == "sticker":
+        file_id = message.sticker.file_id
+
+    if file_id:
+        lang = await user_lang(message.from_user.id)
+        text = "ID файла: {}" if lang == "ru" else "Файлдын IDси: {}"
+        await message.answer(text.format(file_id))

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ sys.stdout.reconfigure(encoding='utf-8', errors='replace')
 
 import asyncio
 from aiogram import Bot, Dispatcher
-from handlers import start, calc, profiles, parser
+from handlers import start, calc, profiles, parser, file_id
 from methods import admin, users
 from keyboards import menu
 from config import BOT_TOKEN
@@ -20,7 +20,8 @@ async def main():
         users.router,
         calc.router,
         profiles.router,
-        parser.router
+        parser.router,
+        file_id.router
     )
     # Schedule poll_news as a background task
     asyncio.create_task(poll_news())


### PR DESCRIPTION
## Summary
- add a new handler that replies with the file ID when users send files in private chat
- include the new router in the bot startup

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6861588c289c8332a9ed5e92bcfcc526