### PR TITLE
Implement scanning of certificate before admin forward

### DIFF
--- a/handlers/profiles.py
+++ b/handlers/profiles.py
@@ -4,6 +4,7 @@ from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
 from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup, CallbackQuery, WebAppInfo
 from methods.profiles import ProfileManager
+from methods.scan import DocScanner
 from methods.users import user_lang
 from methods.validators import validate_score
 from keyboards import menu
@@ -345,7 +346,9 @@ async def handle_scan(message: types.Message):
         if image_data:
             header, b64 = image_data.split(",", 1)
             image_bytes = base64.b64decode(b64)
-            bio = BytesIO(image_bytes)
+            scanner = DocScanner()
+            processed = scanner.scan_bytes(image_bytes)
+            bio = BytesIO(processed)
             bio.name = "scan.jpg"
             caption = (
                 f"📄 Скан от <a href='tg://user?id={message.from_user.id}'>"


### PR DESCRIPTION
## Summary
- extract document scanning logic into `_process_image`
- add `scan_bytes` to handle image bytes
- use new scanning step when a user uploads a certificate so the admin receives the processed scan

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6861927996ac83329bd0508cff93fb5a