### PR TITLE
Unify announcement and broadcast features

### DIFF
--- a/keyboards/menu.py
+++ b/keyboards/menu.py
@@ -164,8 +164,7 @@ async def menu_admin(message: types.Message):
         [
             types.KeyboardButton(text="Подсчет баллов ОРТ"),
             types.KeyboardButton(text="Профиль"),
-            types.KeyboardButton(text="Рассылка"),
-            types.KeyboardButton(text="Анонс")
+            types.KeyboardButton(text="Рассылка")
         ],
         [
             types.KeyboardButton(text="Статистика")


### PR DESCRIPTION
## Summary
- merge `Анонс` and `Рассылка` menu options
- implement group auto-registration via the phrase `сезам откройся`
- add selection between groups or all users for broadcasts
- support pinning options for group broadcasts
- show preview message exactly as users will see

## Testing
- `python -m py_compile methods/admin.py keyboards/menu.py`

------
https://chatgpt.com/codex/tasks/task_e_6868f3148388833292d59247a850ab58