### PR TITLE
Improve quiz page styling

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,10 +4,72 @@
     <meta charset="UTF-8">
     <title>Quiz</title>
     <style>
-        body { font-family: Arial, sans-serif; padding: 20px; }
-        .task { margin-bottom: 30px; }
-        img { max-width: 100%; height: auto; display: block; margin-bottom: 10px; }
-        label { margin-right: 10px; }
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+            text-align: center;
+        }
+        .task {
+            margin-bottom: 30px;
+        }
+        img {
+            max-width: 100%;
+            height: auto;
+            display: block;
+            margin: 0 auto 10px;
+        }
+        .option {
+            display: inline-block;
+            border-radius: 50%;
+            overflow: hidden;
+        }
+        .option input {
+            display: none;
+        }
+        .option span {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 40px;
+            height: 40px;
+            border-radius: 50%;
+            border: 2px solid #007BFF;
+            color: #007BFF;
+            font-weight: bold;
+            margin: 0 5px;
+            cursor: pointer;
+            user-select: none;
+            transition: background-color 0.2s, transform 0.1s;
+            -webkit-tap-highlight-color: transparent;
+        }
+        .option span:active {
+            transform: scale(0.95);
+        }
+        .option input:checked + span {
+            background-color: #007BFF;
+            color: white;
+        }
+        #submitBtn {
+            margin-top: 20px;
+            padding: 10px 20px;
+            font-size: 16px;
+            background-color: #28a745;
+            color: white;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+        }
+        #submitBtn:hover {
+            background-color: #218838;
+        }
+        #submitBtn:active {
+            background-color: #1e7e34;
+        }
+        #result {
+            margin-top: 20px;
+            font-size: 24px;
+            font-weight: bold;
+        }
     </style>
 </head>
 <body>
@@ -33,12 +95,15 @@
                 div.appendChild(img);
                 ['a','b','c','d','e'].forEach(opt => {
                     const label = document.createElement('label');
+                    label.className = 'option';
                     const input = document.createElement('input');
                     input.type = 'radio';
                     input.name = `q${id}`;
                     input.value = opt;
+                    const span = document.createElement('span');
+                    span.textContent = opt.toUpperCase();
                     label.appendChild(input);
-                    label.append(` ${opt.toUpperCase()}`);
+                    label.appendChild(span);
                     div.appendChild(label);
                 });
                 quizContainer.appendChild(div);


### PR DESCRIPTION
## Summary
- center content and style quiz option buttons
- render options as circular buttons with letters inside
- style finish button and result text

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_686a40c6d1048332ae1e661cd7b78802