### PR TITLE
Fix quiz scoring and extend tests

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -181,10 +181,11 @@
         });
 
     document.getElementById('submitBtn').addEventListener('click', () => {
+        const map = {a: 'А', b: 'Б', c: 'В', d: 'Г', e: 'Д'};
         let score = 0;
         for (const id in answers) {
             const checked = document.querySelector(`input[name=q${id}]:checked`);
-            if (checked && checked.value === answers[id]) score++;
+            if (checked && map[checked.value] === answers[id]) score++;
         }
         resultDiv.textContent = `Ваш результат: ${score}`;
         if (window.Telegram && Telegram.WebApp) {

--- a/handlers/tests.py
+++ b/handlers/tests.py
@@ -20,7 +20,7 @@ async def choose_topic(message: types.Message):
 async def list_tests(callback: types.CallbackQuery):
     """Show available tests for the selected topic."""
     builder = InlineKeyboardBuilder()
-    for i in range(1, 11):
+    for i in range(1, 17):
         builder.button(text=str(i), web_app=WebAppInfo(url=f"{QUIZ_WEBAPP_BASE_URL}?test={i}"))
     builder.adjust(1)
     await callback.message.answer("Выберите тест:", reply_markup=builder.as_markup())


### PR DESCRIPTION
## Summary
- fix evaluation logic in `docs/index.html` for Cyrillic answers
- display all 16 available quizzes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686eb4eae36c8332be5f67b74ac5aeb6