### PR TITLE
Add per-topic test scores and quiz feedback

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -93,6 +93,16 @@
             transform: scale(1.07);
             transform-origin: center;
         }
+
+        .option.correct span {
+            background-color: #28a745;
+            color: #ffffff;
+        }
+
+        .option.wrong span {
+            background-color: #dc3545;
+            color: #ffffff;
+        }
         
         /* момент нажатия */
         .option:active span {
@@ -185,11 +195,29 @@
         let score = 0;
         for (const id in answers) {
             const checked = document.querySelector(`input[name=q${id}]:checked`);
-            if (checked && map[checked.value] === answers[id]) score++;
+            const correctLetter = answers[id];
+            const correctValue = Object.keys(map).find(k => map[k] === correctLetter);
+
+            document.querySelectorAll(`input[name=q${id}]`).forEach(inp => {
+                const label = inp.parentElement;
+                inp.disabled = true;
+                if (inp.value === correctValue) {
+                    label.classList.add('correct');
+                }
+                if (inp.checked && inp.value !== correctValue) {
+                    label.classList.add('wrong');
+                }
+            });
+
+            if (checked && map[checked.value] === correctLetter) score++;
         }
         resultDiv.textContent = `Ваш результат: ${score}`;
         if (window.Telegram && Telegram.WebApp) {
-            Telegram.WebApp.sendData(JSON.stringify({quizScore: score}));
+            Telegram.WebApp.sendData(JSON.stringify({
+                topic: 'arithmetic',
+                test: testNum,
+                score: score
+            }));
         }
     });
     </script>

--- a/handlers/profiles.py
+++ b/handlers/profiles.py
@@ -417,9 +417,14 @@ async def handle_scan(message: types.Message):
                     reply_markup=await get_profile_keyboard(lang)
                 )
                 return
-        if "quizScore" in data:
-            score = int(data["quizScore"])
-            await profile_manager.update_quiz_score(message.from_user.id, score)
+        if all(k in data for k in ("topic", "test", "score")):
+            score = int(data["score"])
+            await profile_manager.update_test_score(
+                message.from_user.id,
+                data["topic"],
+                str(data["test"]),
+                score
+            )
             await message.answer(
                 f"Ваш результат теста: {score}",
                 reply_markup=await get_profile_keyboard(lang)


### PR DESCRIPTION
## Summary
- track test results per topic instead of single quiz score
- mark correct and wrong answers on quiz page
- accept topic/test score data from WebApp

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686eb7200d5c83329d0ebd70f8cf6e0b