### PR TITLE
Add percentage tests support

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -146,8 +146,9 @@
     const resultDiv = document.getElementById('result');
     let answers = {};
     const params = new URLSearchParams(window.location.search);
+    const topic = params.get('topic') || 'arithmetics';
     const testNum = params.get('test') || '1';
-    const answersFile = `img/arithmetics/test_${testNum}.json`;
+    const answersFile = `img/${topic}/test_${testNum}.json`;
 
     fetch(answersFile)
         .then(r => r.json())
@@ -170,7 +171,7 @@
                 div.appendChild(header);
 
                 const img = document.createElement('img');
-                img.src = `img/arithmetics/${id}.png`;
+                img.src = `img/${topic}/${id}.png`;
                 div.appendChild(img);
                 const displayLetters = ['А','Б','В','Г','Д'];
                 ['a','b','c','d','e'].forEach((opt, idx) => {
@@ -214,7 +215,7 @@
         resultDiv.textContent = `Ваш результат: ${score}`;
         if (window.Telegram && Telegram.WebApp) {
             Telegram.WebApp.sendData(JSON.stringify({
-                topic: 'arithmetic',
+                topic: topic,
                 test: testNum,
                 score: score
             }));

--- a/handlers/tests.py
+++ b/handlers/tests.py
@@ -13,15 +13,33 @@ async def choose_topic(message: types.Message):
     """Prompt user to choose a test topic."""
     builder = InlineKeyboardBuilder()
     builder.row(InlineKeyboardButton(text="Арифметика", callback_data="topic_arithmetic"))
+    builder.row(InlineKeyboardButton(text="Проценты", callback_data="topic_percent"))
     await message.answer("Выберите тему:", reply_markup=builder.as_markup())
 
 
 @router.callback_query(F.data == "topic_arithmetic")
-async def list_tests(callback: types.CallbackQuery):
-    """Show available tests for the selected topic."""
+async def list_arithmetic_tests(callback: types.CallbackQuery):
+    """Show available arithmetic tests."""
     builder = InlineKeyboardBuilder()
     for i in range(1, 17):
-        builder.button(text=str(i), web_app=WebAppInfo(url=f"{QUIZ_WEBAPP_BASE_URL}?test={i}"))
+        builder.button(
+            text=str(i),
+            web_app=WebAppInfo(url=f"{QUIZ_WEBAPP_BASE_URL}?topic=arithmetics&test={i}")
+        )
+    builder.adjust(1)
+    await callback.message.answer("Выберите тест:", reply_markup=builder.as_markup())
+    await callback.answer()
+
+
+@router.callback_query(F.data == "topic_percent")
+async def list_percent_tests(callback: types.CallbackQuery):
+    """Show available percent tests."""
+    builder = InlineKeyboardBuilder()
+    for i in range(1, 11):
+        builder.button(
+            text=str(i),
+            web_app=WebAppInfo(url=f"{QUIZ_WEBAPP_BASE_URL}?topic=percents&test={i}")
+        )
     builder.adjust(1)
     await callback.message.answer("Выберите тест:", reply_markup=builder.as_markup())
     await callback.answer()


### PR DESCRIPTION
## Summary
- support new `percents` test section in index.html
- update test handler to offer arithmetic and percent topics

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f869ea9d08332bdd2932b417fe684