### PR TITLE
Add radicals tests section

### DIFF
--- a/handlers/tests.py
+++ b/handlers/tests.py
@@ -14,6 +14,7 @@ async def choose_topic(message: types.Message):
     builder = InlineKeyboardBuilder()
     builder.row(InlineKeyboardButton(text="Арифметика", callback_data="topic_arithmetic"))
     builder.row(InlineKeyboardButton(text="Проценты", callback_data="topic_percent"))
+    builder.row(InlineKeyboardButton(text="Корни", callback_data="topic_radical"))
     await message.answer("Выберите тему:", reply_markup=builder.as_markup())
 
 
@@ -39,6 +40,20 @@ async def list_percent_tests(callback: types.CallbackQuery):
         builder.button(
             text=str(i),
             web_app=WebAppInfo(url=f"{QUIZ_WEBAPP_BASE_URL}?topic=percents&test={i}")
+        )
+    builder.adjust(1)
+    await callback.message.answer("Выберите тест:", reply_markup=builder.as_markup())
+    await callback.answer()
+
+
+@router.callback_query(F.data == "topic_radical")
+async def list_radical_tests(callback: types.CallbackQuery):
+    """Show available radical (root) tests."""
+    builder = InlineKeyboardBuilder()
+    for i in range(1, 11):
+        builder.button(
+            text=str(i),
+            web_app=WebAppInfo(url=f"{QUIZ_WEBAPP_BASE_URL}?topic=radicals&test={i}")
         )
     builder.adjust(1)
     await callback.message.answer("Выберите тест:", reply_markup=builder.as_markup())


### PR DESCRIPTION
## Summary
- allow selecting Корни tests in Telegram menu
- support listing radicals tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686fb65bde248332aa55da07751fe2a1