### PR TITLE
Add periodic task generator and poll sender

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -27,3 +27,7 @@ OWNER_ID = 123456789
 GROUP_ID = -1001234567890
 DATA_FILE = "data.json"
 MAX_SCORE = 245
+
+# Task generator settings
+OPENAI_API_KEY = "your_openai_api_key_here"
+TASK_CREATION_INTERVAL = 3600  # seconds

--- a/exercises/api.py
+++ b/exercises/api.py
@@ -133,19 +133,21 @@ def generate_task_images(
     for fmt in output_formats:
         if fmt not in config.SUPPORTED_OUTPUT_FORMATS:
             raise TaskGenerationError(f"Неподдерживаемый формат: {fmt}")
-    
+
     result = {
         "task_type": None,
         "task_data": None,
+        "task_meta": None,
         "files": {},
         "success": False
     }
-    
+
     try:
         # Initialize components
         api_client = TaskAPIClient(api_key)
         task = api_client.generator.generate_random_task()
         result["task_type"] = task["тип_задачи"]
+        result["task_meta"] = task
         
         if task["тип_задачи"] == "COMPARISON":
             result.update(_generate_comparison_task(api_client, task, output_formats, dpi))

--- a/handlers/creator.py
+++ b/handlers/creator.py
@@ -1,0 +1,77 @@
+"""Periodic task sender.
+
+Generates mathematical tasks and posts them to the group chat. After the
+image is sent, a poll with answer options is posted immediately. The poll
+options use only the letters "А", "Б", "В", "Г" and optionally "Д" depending
+on the task type.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from aiogram import Bot, Router
+from aiogram.types import FSInputFile
+
+from exercises.api import generate_task_images
+import config
+
+
+router = Router()
+
+
+async def _send_task(bot: Bot) -> None:
+    """Generate a task image and send it followed by a poll."""
+    result = generate_task_images(
+        api_key=config.OPENAI_API_KEY, output_formats=["png"]
+    )
+    if not result.get("success"):
+        return
+
+    meta = result.get("task_meta", {})
+    caption = (
+        f"Класс: {meta.get('класс')}\n"
+        f"Тема: {meta.get('тема')}\n"
+        f"Подтема: {meta.get('подтема')}\n"
+        f"Сложность: {meta.get('сложность')}"
+    )
+
+    photo = FSInputFile(result["files"]["png"])
+    await bot.send_photo(config.GROUP_ID, photo, caption=caption)
+
+    task_type = result.get("task_type")
+    task_data = result.get("task_data", {})
+
+    if task_type == "ABCDE":
+        options = ["А", "Б", "В", "Г", "Д"]
+        letter_map = {"A": 0, "B": 1, "C": 2, "D": 3, "E": 4}
+        correct = letter_map.get(task_data.get("correct_answer", "").upper(), 0)
+    else:  # COMPARISON and others with four options
+        options = ["А", "Б", "В", "Г"]
+        symbols = [">", "<", "=", "недостаточно данных"]
+        ans = task_data.get("correct_answer")
+        correct = symbols.index(ans) if ans in symbols else 0
+
+    await bot.send_poll(
+        config.GROUP_ID,
+        "Выберите правильный ответ",
+        options=options,
+        type="quiz",
+        correct_option_id=correct,
+        is_anonymous=False,
+    )
+
+
+async def _periodic_sender(bot: Bot, interval: int) -> None:
+    """Send tasks to the group every ``interval`` seconds."""
+    while True:
+        await _send_task(bot)
+        await asyncio.sleep(interval)
+
+
+@router.startup()
+async def _on_start(bot: Bot) -> None:
+    """Start the background task on bot startup."""
+    interval = getattr(config, "TASK_CREATION_INTERVAL", 3600)
+    asyncio.create_task(_periodic_sender(bot, interval))
+

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ sys.stdout.reconfigure(encoding='utf-8', errors='replace')
 
 import asyncio
 from aiogram import Bot, Dispatcher
-from handlers import start, calc, profiles, parser, file_id, tests
+from handlers import start, calc, profiles, parser, file_id, tests, creator
 from methods import admin, users
 from keyboards import menu
 from config import BOT_TOKEN
@@ -22,7 +22,8 @@ async def main():
         profiles.router,
         tests.router,
         #parser.router,
-        file_id.router
+        file_id.router,
+        creator.router
     )
     # Schedule poll_news as a background task
     #asyncio.create_task(poll_news())


### PR DESCRIPTION
## Summary
- generate task metadata in API responses
- periodically create tasks and post to group with poll
- wire new creator router into bot and expose config options

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a73a5c15ec833286dce0e4397ca818